### PR TITLE
Use material theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Uses [mkdocs](https://www.mkdocs.org/) to generate static HTML.
 Changes to the `main` branch are automatically published to the
 website using Github Actions.
 
-You can preview local changes using `pip install mkdocs`; `mkdocs serve`,
+You can preview local changes using `pip install mkdocs-material`; `mkdocs serve`,
 then visiting http://127.0.0.1:8000/
 
 ## Creating Screenshots

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: K-9 Mail
-theme: readthedocs
+theme: material
 markdown_extensions:
   - toc
 nav:


### PR DESCRIPTION
Use the `material` theme in the config so the locally generated site looks like the one deployed by the GitHub action.