### PR TITLE
Make site available under docs.k9mail.app

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+docs.k9mail.app

--- a/docs/en/current/index.md
+++ b/docs/en/current/index.md
@@ -1,9 +1,8 @@
 # K-9 Mail User Manual
 
-NOTE - THIS DOCUMENTATION IS A DRAFT, NOT FOR PUBLIC CONSUMPTION YET.
+Welcome to the user manual for [K-9 Mail](https://k9mail.app/) 6.000.
 
-SEE THE MAIN DOCUMENTATION AT https://k9mail.app/documentation/
-
-Welcome to the user manual for [K-9 Mail](https://k9mail.app/) 5.600.
+Please note that this documentation is outdated in certain places. If you want to help fix this situation, check out
+the [k9mail-docs repository](https://github.com/k9mail/k9mail-docs).
 
 If you have questions that can't be answered by these pages please visit our [support forum](https://forum.k9mail.app/).


### PR DESCRIPTION
What we have in this repo is better than what we have on the website. So I want to make this the official documentation as soon as possible.